### PR TITLE
fix problem:only get the first ip addr (usually 127.0.0.1) in the ip …

### DIFF
--- a/CommonUtilitiesLib/SocketUtils.cpp
+++ b/CommonUtilitiesLib/SocketUtils.cpp
@@ -549,9 +549,6 @@ Bool16 SocketUtils::IncrementIfReqIter(char** inIfReqIter, ifreq* ifr)
     //if the length of the addr is 0, use the family to determine
     //what the addr size is
     if (ifr->ifr_addr.sa_len == 0)
-#else
-    *inIfReqIter += sizeof(ifr->ifr_name) + 0;
-#endif
     {
         switch (ifr->ifr_addr.sa_family)
         {
@@ -565,6 +562,9 @@ Bool16 SocketUtils::IncrementIfReqIter(char** inIfReqIter, ifreq* ifr)
 //              return false;
         }
     }
+#else
+    *inIfReqIter += sizeof(struct ifreq);
+#endif
     return true;
 }
 #endif


### PR DESCRIPTION
…addr list

In CentOS 6.7 x64, while in fun IncrementIfReqIter ,I found that:
sizeof(struct ifreq)=40,
sizeof(ifr->ifr_name)=16,
sizeof(struct sockaddr_in)=16,
thus sizeof(struct ifreq) > sizeof(ifr->ifr_name)+sizeof(struct sockaddr_in),
so it can not move inIfReqIter to the right place,
and the reason is : sizeof(struct ifmap)=24 > sizeof(struct sockaddr_in)

By submitting a request, you represent that you have the right to license
your contribution to the community, and agree that your contributions are
licensed under the [Apple Public Source License Version 2.0](APPLE_LICENSE).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Darwin Streaming Server's licensing terms.
